### PR TITLE
rm support for old julia versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: julia
 os:
   - linux
 julia:
-  - 0.6
-  - 0.7
   - 1.0
+  - 1.1
+  - 1.2
+  - nightly
 notifications:
   email: false
 git:
@@ -16,8 +17,7 @@ git:
 matrix:
   allow_failures:
   - julia: nightly
-  - julia: 0.6
-  - julia: 1.0
+  - julia: 1.2
 
 ## uncomment and modify the following lines to manually install system packages
 #addons:


### PR DESCRIPTION
Some of the builds failed because they are not compatible anymore with old julia versions.